### PR TITLE
Fix sign-up flow view model persistence

### DIFF
--- a/DesignDaily/AppCordinator/AppCoordinator.swift
+++ b/DesignDaily/AppCordinator/AppCoordinator.swift
@@ -11,6 +11,9 @@ class AppCoordinator: ObservableObject {
     @Published var path = NavigationPath()
     @Published var rootView: Destination = .listsView
 
+    // Shared ViewModels
+    var signUpViewModel: SignUpViewModel?
+
     // Shared Services
     let userService: UserServiceProtocol
     let productService: ProductServiceProtocol
@@ -20,6 +23,9 @@ class AppCoordinator: ObservableObject {
         didSet {
             rootView = isAuthenticated ? .listsView : .login
             resetNavigation()
+            if isAuthenticated {
+                signUpViewModel = nil
+            }
         }
     }
 

--- a/DesignDaily/AppCordinator/CoordinatorView.swift
+++ b/DesignDaily/AppCordinator/CoordinatorView.swift
@@ -26,10 +26,14 @@ struct CoordinatorView: View {
             LoginView(viewModel: LoginViewModel(userService: coordinator.userService, coordinator: coordinator))
                 .environmentObject(coordinator)
         case .signUpStep1:
-            SignUpStep1View(viewModel: SignUpViewModel(userService: coordinator.userService, coordinator: coordinator))
+            let viewModel = coordinator.signUpViewModel ?? SignUpViewModel(userService: coordinator.userService, coordinator: coordinator)
+            coordinator.signUpViewModel = viewModel
+            SignUpStep1View(viewModel: viewModel)
                 .environmentObject(coordinator)
         case .signUpStep2:
-            SignUpStep2View(viewModel: SignUpViewModel(userService: coordinator.userService, coordinator: coordinator))
+            let viewModel = coordinator.signUpViewModel ?? SignUpViewModel(userService: coordinator.userService, coordinator: coordinator)
+            coordinator.signUpViewModel = viewModel
+            SignUpStep2View(viewModel: viewModel)
                 .environmentObject(coordinator)
         case .listsView:
             ListsView(viewModel: ListsViewModel(productService: coordinator.productService))


### PR DESCRIPTION
## Summary
- hold the `SignUpViewModel` in `AppCoordinator`
- reuse the same view model for step 1 and step 2
- clear the sign-up view model after authentication

## Testing
- `swift --version`