### PR TITLE
Add unit tests for login and sign-up view models

### DIFF
--- a/DesignDaily/DesignDailyTests/DesignDailyTests.swift
+++ b/DesignDaily/DesignDailyTests/DesignDailyTests.swift
@@ -1,17 +1,73 @@
-//
-//  DesignDailyTests.swift
-//  DesignDailyTests
-//
-//  Created by Yigit Dayı on 8.10.2024.
-//
-
 import Testing
+import SwiftUI
 @testable import DesignDaily
 
-struct DesignDailyTests {
-
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+@MainActor
+struct LoginViewModelTests {
+    @Test func loginSuccess() async throws {
+        let service = MockUserService()
+        let coordinator = AppCoordinator(userService: service, productService: MockProductService())
+        let viewModel = LoginViewModel(userService: service, coordinator: coordinator)
+        viewModel.email = "test@example.com"
+        viewModel.password = "password"
+        await viewModel.login()
+        #expect(coordinator.isAuthenticated == true)
+        #expect(viewModel.errorMessage == nil)
+        #expect(viewModel.isLoading == false)
     }
 
+    @Test func loginFailure() async throws {
+        let service = MockUserService(shouldFail: true)
+        let coordinator = AppCoordinator(userService: service, productService: MockProductService())
+        let viewModel = LoginViewModel(userService: service, coordinator: coordinator)
+        viewModel.email = "wrong@example.com"
+        viewModel.password = "wrong"
+        await viewModel.login()
+        #expect(coordinator.isAuthenticated == false)
+        #expect(viewModel.errorMessage == "Invalid credentials")
+        #expect(viewModel.isLoading == false)
+    }
+}
+
+@MainActor
+struct SignUpViewModelTests {
+    @Test func signUpValidationFails() async throws {
+        let service = RecordingUserService()
+        let coordinator = AppCoordinator(userService: service, productService: MockProductService())
+        let viewModel = SignUpViewModel(userService: service, coordinator: coordinator)
+        viewModel.fullName = ""
+        viewModel.email = "test@example.com"
+        viewModel.password = "password"
+        await viewModel.signUp()
+        #expect(service.signUpCallCount == 0)
+        #expect(coordinator.isAuthenticated == false)
+        #expect(viewModel.errorMessage == "Please fill all fields.")
+        #expect(viewModel.isLoading == false)
+    }
+
+    @Test func signUpSuccess() async throws {
+        let service = MockUserService()
+        let coordinator = AppCoordinator(userService: service, productService: MockProductService())
+        let viewModel = SignUpViewModel(userService: service, coordinator: coordinator)
+        viewModel.fullName = "Test User"
+        viewModel.email = "test@example.com"
+        viewModel.password = "password"
+        await viewModel.signUp()
+        #expect(coordinator.isAuthenticated == true)
+        #expect(viewModel.errorMessage == nil)
+        #expect(viewModel.isLoading == false)
+    }
+
+    @Test func signUpFailure() async throws {
+        let service = MockUserService(shouldFail: true)
+        let coordinator = AppCoordinator(userService: service, productService: MockProductService())
+        let viewModel = SignUpViewModel(userService: service, coordinator: coordinator)
+        viewModel.fullName = "Test User"
+        viewModel.email = "test@example.com"
+        viewModel.password = "password"
+        await viewModel.signUp()
+        #expect(coordinator.isAuthenticated == false)
+        #expect(viewModel.errorMessage == "Sign up failed")
+        #expect(viewModel.isLoading == false)
+    }
 }

--- a/DesignDailyTests/DesignDailyTests.swift
+++ b/DesignDailyTests/DesignDailyTests.swift
@@ -1,17 +1,73 @@
-//
-//  DesignDailyTests.swift
-//  DesignDailyTests
-//
-//  Created by Yigit Dayı on 8.10.2024.
-//
-
 import Testing
+import SwiftUI
 @testable import DesignDaily
 
-struct DesignDailyTests {
-
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+@MainActor
+struct LoginViewModelTests {
+    @Test func loginSuccess() async throws {
+        let service = MockUserService()
+        let coordinator = AppCoordinator(userService: service, productService: MockProductService())
+        let viewModel = LoginViewModel(userService: service, coordinator: coordinator)
+        viewModel.email = "test@example.com"
+        viewModel.password = "password"
+        await viewModel.login()
+        #expect(coordinator.isAuthenticated == true)
+        #expect(viewModel.errorMessage == nil)
+        #expect(viewModel.isLoading == false)
     }
 
+    @Test func loginFailure() async throws {
+        let service = MockUserService(shouldFail: true)
+        let coordinator = AppCoordinator(userService: service, productService: MockProductService())
+        let viewModel = LoginViewModel(userService: service, coordinator: coordinator)
+        viewModel.email = "wrong@example.com"
+        viewModel.password = "wrong"
+        await viewModel.login()
+        #expect(coordinator.isAuthenticated == false)
+        #expect(viewModel.errorMessage == "Invalid credentials")
+        #expect(viewModel.isLoading == false)
+    }
+}
+
+@MainActor
+struct SignUpViewModelTests {
+    @Test func signUpValidationFails() async throws {
+        let service = RecordingUserService()
+        let coordinator = AppCoordinator(userService: service, productService: MockProductService())
+        let viewModel = SignUpViewModel(userService: service, coordinator: coordinator)
+        viewModel.fullName = ""
+        viewModel.email = "test@example.com"
+        viewModel.password = "password"
+        await viewModel.signUp()
+        #expect(service.signUpCallCount == 0)
+        #expect(coordinator.isAuthenticated == false)
+        #expect(viewModel.errorMessage == "Please fill all fields.")
+        #expect(viewModel.isLoading == false)
+    }
+
+    @Test func signUpSuccess() async throws {
+        let service = MockUserService()
+        let coordinator = AppCoordinator(userService: service, productService: MockProductService())
+        let viewModel = SignUpViewModel(userService: service, coordinator: coordinator)
+        viewModel.fullName = "Test User"
+        viewModel.email = "test@example.com"
+        viewModel.password = "password"
+        await viewModel.signUp()
+        #expect(coordinator.isAuthenticated == true)
+        #expect(viewModel.errorMessage == nil)
+        #expect(viewModel.isLoading == false)
+    }
+
+    @Test func signUpFailure() async throws {
+        let service = MockUserService(shouldFail: true)
+        let coordinator = AppCoordinator(userService: service, productService: MockProductService())
+        let viewModel = SignUpViewModel(userService: service, coordinator: coordinator)
+        viewModel.fullName = "Test User"
+        viewModel.email = "test@example.com"
+        viewModel.password = "password"
+        await viewModel.signUp()
+        #expect(coordinator.isAuthenticated == false)
+        #expect(viewModel.errorMessage == "Sign up failed")
+        #expect(viewModel.isLoading == false)
+    }
 }

--- a/DesignDailyTests/TestHelpers.swift
+++ b/DesignDailyTests/TestHelpers.swift
@@ -1,0 +1,25 @@
+import Foundation
+@testable import DesignDaily
+
+final class RecordingUserService: UserServiceProtocol {
+    var loginCallCount = 0
+    var signUpCallCount = 0
+    var loginResult: Result<User, Error>
+    var signUpResult: Result<User, Error>
+
+    init(loginResult: Result<User, Error> = .success(User(id: UUID(), fullName: "Test", email: "test@example.com", biography: "", contactInfo: "", profileImageName: "")),
+         signUpResult: Result<User, Error> = .success(User(id: UUID(), fullName: "Test", email: "test@example.com", biography: "", contactInfo: "", profileImageName: ""))) {
+        self.loginResult = loginResult
+        self.signUpResult = signUpResult
+    }
+
+    func login(email: String, password: String) async throws -> User {
+        loginCallCount += 1
+        return try loginResult.get()
+    }
+
+    func signUp(user: User, password: String) async throws -> User {
+        signUpCallCount += 1
+        return try signUpResult.get()
+    }
+}


### PR DESCRIPTION
## Summary
- add a test helper to record service calls
- implement LoginViewModel and SignUpViewModel tests
- duplicate tests for the nested test target

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*
- `swift --version`